### PR TITLE
Change repository due to docker rate limitations

### DIFF
--- a/.template_new
+++ b/.template_new
@@ -28,8 +28,8 @@ container_permissions PGID 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 # how users select an image; the 1st image is the default. If only 1, it's ok!
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/nzbget:latest
-linuxserver/nzbget:testing
+ghcr.io/linuxserver/nzbget:latest
+ghcr.io/linuxserver/nzbget:testing
 EOF
 
 # YML EXPORT ###################################################################


### PR DESCRIPTION
Changed linuxserver.io repository to the ghcr.io prefix per the linuxserver.io team due to the rate limits now being imposed by docker.com